### PR TITLE
Build optimized Linux executable for AWS Lambda

### DIFF
--- a/.github/workflows/aws-lambda.yml
+++ b/.github/workflows/aws-lambda.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build Lambda bootstrap
         run: |
-          GOOS=linux GOARCH=amd64 go build -o bootstrap main.go
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bootstrap main.go
           zip bootstrap.zip bootstrap
           aws lambda update-function-code --function-name BaoSaveLineBot --zip-file fileb://bootstrap.zip
 


### PR DESCRIPTION
Previously, the Lambda bootstrap was built without disabling CGO. Now, CGO_ENABLED=0 is set to optimize the build process for Linux. The updated bootstrap binary is then zipped and deployed to the BaoSaveLineBot Lambda function.