### PR TITLE
Save content to "./tmp" or "/tmp"

### DIFF
--- a/internal/domain/drive/drive.go
+++ b/internal/domain/drive/drive.go
@@ -6,10 +6,24 @@ import (
 	"os"
 )
 
-// Save content to ./tmp , /tmp for lambda
+// Save content to  "./tmp" or "/tmp"
 func SaveContent(content io.ReadCloser) (*os.File, error) {
 	defer content.Close()
-	file, err := os.CreateTemp("/tmp", "")
+
+	// Check if it is in lambda
+	tmpDir := "/tmp"
+	if _, err := os.Stat(tmpDir); os.IsNotExist(err) {
+		// If not in lambda save to ./tmp
+		tmpDir = "./tmp"
+		if _, err := os.Stat(tmpDir); os.IsNotExist(err) {
+			// If ./tmp is not exist, create folder
+			if err := os.Mkdir(tmpDir, os.ModePerm); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	file, err := os.CreateTemp(tmpDir, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit updates the `SaveContent` function to first check if the code is running in a Lambda function. If it is, the content is saved to the "/tmp" directory. If it is not running in Lambda, it checks if the "./tmp" directory exists. If it does not exist, it creates the directory before saving the content.